### PR TITLE
changed a doc string specifing the the response_maker()  describing t…

### DIFF
--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -26,6 +26,7 @@ from packit_service.models import (
 
 def response_maker(result: Any, status: HTTPStatus = HTTPStatus.OK):
     """response_maker is a wrapper around flask's make_response"""
+    """This function uses Jsonify and directly sets the status code than being a wrapper to it """
     resp = jsonify(result)
     resp.status_code = status.value
     return resp

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -109,10 +109,9 @@ def get_sync_release_info(sync_release_model: SyncReleaseModel):
 
 
 def get_project_info(project: Union[AnityaProjectModel, GitProjectModel]):
-    result_dict = {}
+    result_dict = dict()
 
-    anitya_project_id = anitya_project_name = anitya_package = None
-    project_url = repo_name = repo_namespace = None
+    anitya_project_id = anitya_project_name = anitya_package = project_url = repo_name = repo_namespace = None
 
     if isinstance(project, AnityaProjectModel):
         anitya_project_id = project.project_id if project else ""

--- a/packit_service/service/api/utils.py
+++ b/packit_service/service/api/utils.py
@@ -109,10 +109,15 @@ def get_sync_release_info(sync_release_model: SyncReleaseModel):
 
 
 def get_project_info(project: Union[AnityaProjectModel, GitProjectModel]):
+    """Changed result_dict={} --> result_dict=dict()
+    
+ This is to avoid none values in the result dictionary"""
     result_dict = dict()
-
+    """change multiple line none value declaration to single line none value declaration for better readability"""
     anitya_project_id = anitya_project_name = anitya_package = project_url = repo_name = repo_namespace = None
 
+    """return "" (empty string) if project is none """
+    
     if isinstance(project, AnityaProjectModel):
         anitya_project_id = project.project_id if project else ""
         anitya_project_name = project.project_name if project else ""


### PR DESCRIPTION
…hat that its uses jsonify and dirctly sets the status code

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
